### PR TITLE
Fix OpenAI model deprecation

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,7 +31,7 @@ form.addEventListener('submit', async (e) => {
                 'Authorization': 'Bearer $CLIENT_SECRET'
             },
             data: {
-                model: 'text-davinci-003',
+                model: 'gpt-3.5-turbo-instruct',
                 prompt: `Translate the following text to ${targetLang}: ${userText}`,
                 max_tokens: 100,
                 temperature: 0.3


### PR DESCRIPTION
## Summary
- update the deprecated `text-davinci-003` model to `gpt-3.5-turbo-instruct`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e085712a08326a12b02c43df0c53a